### PR TITLE
管理者、消費者と配送先テーブルの作成 #10

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,2 @@
+class Address < ApplicationRecord
+end

--- a/db/migrate/20210416152121_add_column_to_customers.rb
+++ b/db/migrate/20210416152121_add_column_to_customers.rb
@@ -1,0 +1,21 @@
+class AddColumnToCustomers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :customers, :last_name, :string
+    add_column :customers, :first_name, :string
+    add_column :customers, :last_name_kana, :string
+    add_column :customers, :first_name_kana, :string
+    add_column :customers, :postal_code, :string
+    add_column :customers, :address, :string
+    add_column :customers, :telephone_number, :string
+    add_column :customers, :is_deleted, :boolean, default: false
+
+    change_column_null :customers, :last_name, false
+    change_column_null :customers, :first_name, false
+    change_column_null :customers, :last_name_kana, false
+    change_column_null :customers, :first_name_kana, false
+    change_column_null :customers, :postal_code, false
+    change_column_null :customers, :address, false
+    change_column_null :customers, :telephone_number, false
+    change_column_null :customers, :is_deleted, :boolean, false
+  end
+end

--- a/db/migrate/20210416153132_create_addresses.rb
+++ b/db/migrate/20210416153132_create_addresses.rb
@@ -1,0 +1,11 @@
+class CreateAddresses < ActiveRecord::Migration[5.2]
+  def change
+    create_table :addresses do |t|
+      t.integer :customer_id, null: false
+      t.string :name, null: false
+      t.string :postal_code, null: false
+      t.string :address, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_16_152121) do
+ActiveRecord::Schema.define(version: 2021_04_16_153132) do
+
+  create_table "addresses", force: :cascade do |t|
+    t.integer "customer_id", null: false
+    t.string "name", null: false
+    t.string "postal_code", null: false
+    t.string "address", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_16_094625) do
+ActiveRecord::Schema.define(version: 2021_04_16_152121) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -40,6 +40,14 @@ ActiveRecord::Schema.define(version: 2021_04_16_094625) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "last_name", null: false
+    t.string "first_name", null: false
+    t.string "last_name_kana", null: false
+    t.string "first_name_kana", null: false
+    t.string "postal_code", null: false
+    t.string "address", null: false
+    t.string "telephone_number", null: false
+    t.boolean "is_deleted", default: false
     t.index ["email"], name: "index_customers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_customers_on_reset_password_token", unique: true
   end

--- a/test/fixtures/addresses.yml
+++ b/test/fixtures/addresses.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/address_test.rb
+++ b/test/models/address_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AddressTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## マイグレーションファイルにて、管理者と消費者テーブルのカラムを編集
必要はないと考えているが、devise導入のデフォルトで入っている下記のカラムは残した。
- reset_password_token
- reset_password_sent_at
- remember_created_at

余裕があれば、動作に支障がないことを確認した後に削除予定。

## 配送先テーブルを作成
```
$ rails g model address
```
生成されたマイグレーションファイルにて、カラムを追加した。

[テーブル定義書](https://docs.google.com/spreadsheets/d/1QWT4gtCW3OL98uHCRAli8mpK0lLLpkB5P5qnBHkNHUk/edit?usp=sharing)

