### PR TITLE
消費者のviewとcontrollerを編集 #20

### DIFF
--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,5 +1,6 @@
 class Public::CustomersController < ApplicationController
   def show
+    @customer = Customer.find(current_customer.id)
   end
 
   def edit

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -4,8 +4,32 @@ class Public::CustomersController < ApplicationController
   end
 
   def edit
+    @customer = Customer.find(current_customer.id)
+  end
+
+  def update
+    @customer = Customer.find(current_customer.id)
+    @customer.update(customer_params)
+    render 'show'
   end
 
   def unsubscribe
   end
+
+  private
+
+  def customer_params
+    list = [
+      :last_name,
+      :first_name,
+      :last_name_kana,
+      :first_name_kana,
+      :postal_code,
+      :address,
+      :telephone_number,
+      :email
+    ]
+    params.require(:customer).permit(list)
+  end
+
 end

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,14 +1,13 @@
 class Public::CustomersController < ApplicationController
+  before_action :set_customer, only: [:show, :edit, :update, :withdraw]
+
   def show
-    @customer = Customer.find(current_customer.id)
   end
 
   def edit
-    @customer = Customer.find(current_customer.id)
   end
 
   def update
-    @customer = Customer.find(current_customer.id)
     @customer.update(customer_params)
     render 'show'
   end
@@ -17,12 +16,15 @@ class Public::CustomersController < ApplicationController
   end
 
   def withdraw
-    @customer = Customer.find(current_customer.id)
     @customer.update(is_deleted: true)
     redirect_to root_path
   end
 
   private
+
+  def set_customer
+    @customer = Customer.find(current_customer.id)
+  end
 
   def customer_params
     list = [

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -16,6 +16,12 @@ class Public::CustomersController < ApplicationController
   def unsubscribe
   end
 
+  def withdraw
+    @customer = Customer.find(current_customer.id)
+    @customer.update(is_deleted: true)
+    redirect_to root_path
+  end
+
   private
 
   def customer_params

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -1,2 +1,50 @@
 <h1>Public::Customers#edit</h1>
 <p>Find me in app/views/public/customers/edit.html.erb</p>
+
+<%= form_with model: @customer, url: customers_path, local: true do |f| %>
+  <div class="field">
+    <%= f.label :last_name %><br />
+    <%= f.text_field :last_name, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :first_name %><br />
+    <%= f.text_field :first_name, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :last_name_kana %><br />
+    <%= f.text_field :last_name_kana, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :first_name_kana %><br />
+    <%= f.text_field :first_name_kana, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :postal_code %><br />
+    <%= f.text_field :postal_code, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :address %><br />
+    <%= f.text_field :address, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :telephone_number %><br />
+    <%= f.text_field :telephone_number, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<%= link_to "退会", customers_unsubscribe_path %>

--- a/app/views/public/customers/show.html.erb
+++ b/app/views/public/customers/show.html.erb
@@ -1,2 +1,15 @@
 <h1>Public::Customers#show</h1>
 <p>Find me in app/views/public/customers/show.html.erb</p>
+
+<p>名前(姓): <%= @customer.last_name %></p>
+<p>名前(名): <%= @customer.first_name %></p>
+<p>名前(カナ姓): <%= @customer.last_name_kana %></p>
+<p>名前(カナ名): <%= @customer.first_name_kana %></p>
+<p>郵便番号: <%= @customer.postal_code %></p>
+<p>住所: <%= @customer.address %></p>
+<p>電話番号: <%= @customer.telephone_number %></p>
+<p>メールアドレス: <%= @customer.email %></p>
+<%= link_to "編集", edit_customers_path, class: "btn" %>
+
+<%= link_to "配送先", addresses_path %>
+<%= link_to "注文履歴", orders_path %>

--- a/app/views/public/customers/unsubscribe.html.erb
+++ b/app/views/public/customers/unsubscribe.html.erb
@@ -1,2 +1,6 @@
 <h1>Public::Customers#unsubscribe</h1>
 <p>Find me in app/views/public/customers/unsubscribe.html.erb</p>
+
+<p>本当に退会しますか？</p>
+<%= link_to "退会しない", customers_my_page_path, class: "btn btn-primary" %>
+<%= link_to "退会する", customers_withdraw_path, method: :patch, class: "btn btn-danger" %>


### PR DESCRIPTION
## 消費者のviewとcontorollerを下記の通り編集した。
### マイページ(#show)
- 登録されている会員情報
- 配送先一覧リンク
- 編集ボタン
- 注文履歴一覧リンク
### 会員情報編集(#edit)
- 会員情報入力欄(登録内容をデフォルト表示)
- 退会リンク
- 変更保存ボタン
### 退会確認(#unsubscribe)
- 退会を確認する文章
- 退会しないボタン
- 退会するボタン
## 会員フラグを書き換える#withdrawを追加した。