### PR TITLE
消費者の注文（配送）のviewとcontorollerを編集しました。

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -4,23 +4,47 @@ class Public::OrdersController < ApplicationController
   end
 
   def index
+    @customer = current_customer
+		@orders = @customer.orders
   end
 
   def show
+    @order = Order.find(params[:id])
   end
 
   def confirm
     @order = Order.new(order_params)
-  
+
+    if params[:order][:address_number]=="1"
+      @order.postal_code = current_customer.postal_code
+      @order.address = current_customer.address
+      @order.name = current_customer.last_name + current_customer.first_name
+
+    elsif params[:order][:address_number]=="2"
+
+    elsif params[:order][:address_number]=="3"
+      @order.address = params[:order][:address]
+      @order.name = params[:order][:name]
+      @order.postal_code = params[:order][:postal_code]
+      @order.customer_id = current_customer.id
+      if @order.save
+      end
+    end
+  end
+
+  def create
+    @order = Order.new(order_params)
+    @order.customer_id = current_customer.id
+    @order.save!
+    redirect_to orders_complete_path
   end
 
   def complete
+
   end
-  
+
   private
   def order_params
-    params.require(:order).permit(
-      :customer_id, :postal_code, :address, :name, :shipping_cost, :total_payment, :payment_method, :status
-      )
+    params.require(:order).permit(:customer_id, :postal_code, :address, :name, :shipping_cost, :total_payment, :payment_method, :status)
   end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,6 +1,8 @@
 class Customer < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :orders, dependent: :destroy
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 end
+

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -1,26 +1,43 @@
 <div class="container">
+   
+    <div>
+        <h4>・注文商品確認画面</h4>
+        <p>商品名</p>
+        <P>商品画像</P>
+        <p>商品値段（税込）</p>
+        <p>個数</p>
+        <p>商品合計</p>
+    </div>
     
-    <h1>注文情報確認画面</h1>
+    <div>
+        <h4>・支払い方法</h4>
+        <%= @order.payment_method %>
+    </div>
+
+    <div>
+        <h4>・配送先情報</h4>
+        <P>配送宛先名</P>
+        <%= @order.name %>
+        <p>配送先郵便番号</p>
+        <%= @order.postal_code %>
+        <p>配送先住所</p>
+        <%= @order.address %><br>
+        
+        
     
-    <!--買い物の情報が入る-->
-    <p>商品名</p>
-    <P>商品画像</P>
-    <p>商品値段</p>
-    <p>商品個数</p>
-    <p>お金合計</p>
-    
-    <p>支払い方法</p>
-    
-    -------------------
-    <P>配送宛先名</P>
-    <%= @order.name %>
-    <p>配送先郵便番号</p>
-    <%= @order.postal_code %>
-    <p>配送先住所</p>
-    <%= @order.address %><br>
-    
-    <%= link_to "注文を確定する", orders_complete_path %>
-    
+    </div>
+            
+    <%= form_with(model: @order, local: true, url: orders_complete_path, method: :post) do |f| %>
+        <%= f.hidden_field :payment_method %>
+        <%= f.hidden_field :name %>
+        <%= f.hidden_field :postal_code %>
+        <%= f.hidden_field :address %>
+        <%= f.hidden_field :shipping_cost %>
+        <%= f.hidden_field :total_payment %>
+        <%= f.hidden_field :status %>
+        <%= f.submit %>
+    <% end %>
+
 </div>
 
 

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -1,2 +1,26 @@
-<h1>Public::Orders#index</h1>
-<p>Find me in app/views/public/orders/index.html.erb</p>
+<div class="container">
+  <h1>注文履歴</h1>
+  
+  <% @orders.each do |order| %>
+  <div class="row border border-secondary">
+    <div class="col-3">
+      <h4>注文商品</h4>
+      <p>商品名</p>
+      <P>商品画像</P>
+      <p>商品値段（税込）</p>
+      <p>個数</p>
+      <p>商品合計</p>
+    </div>
+
+    <div class="col-8">
+      <h4>配送先</h4>
+      <p>宛先:<%= order.name %></p>
+      <p>郵便番号:<%= order.postal_code %></p>
+      <p>住所:<%= order.address %></p>
+      <%= link_to '表示する', order_path(order), class: "btn btn-sm btn-danger" %>
+    </div>
+  </div>
+  <% end %>
+
+</div>
+

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -1,32 +1,71 @@
 <div class="container">
   <h3>注文情報入力画面（支払い方法・配送先の選択）</h3>
-  <%= form_with model: @order, url: orders_confirm_path, method: :post, local: true do |f| %>
-  
-    <div class="form-group">
-      <%= f.label :配送先宛名 %><br>
-      <%= f.text_field :name, class:"form-control" %>
-    </div>
-  
-    <div class="form-group">
-      <%= f.label :配送先郵便番号 %><br>
-      <%= f.text_field :postal_code, class:"form-control" %>
-    </div>
-  
-    <div class="form-group">
-      <%= f.label :配送先住所 %><br>
-      <%= f.text_area :address, class:"form-control" %>
-    </div>
-  
-    <!--ここに送料入る-->
-    <!--ここに請求額入る-->
-  
-    <div class="form-group">
+
+
+  <%= form_with(model: @order, local: true, url: orders_confirm_path, method: :post) do |f| %>
+
+  <!--支払い方法選択-->
+
+    <h4>支払い方法選択</h4>
+    <div class="form-group border border-primary">
       <%= f.label :支払い方法選択 %><br>
       <%= f.select :payment_method, options_for_select(Order.payment_methods.keys)  %>
     </div>
-  
+   <!--javascriptで選択後表示させるようにする-->
+   <!--配送先の選択-->
+    <h4>お届け先</h4>
+  　<!--ユーザーの住所-->
+  　<div class="border border-primary">
+    　<label><%= f.radio_button :address_number,1,checked: "checked" %> あなたの住所 </label><br>
+    　<%= current_customer.last_name %><br>
+    　<%= current_customer.first_name %><br>
+    　<%= current_customer.postal_code %><br>
+    　<%= current_customer.address %>
+  　</div>
+
+  　<!--登録されている住所-->
+  　<div class="border border-primary">
+    　<label><%= f.radio_button :address_number,2,checked: "checked" %> 登録されている住所 </label>
+  　</div>
+
+  　<!--新しく登録したい住所-->
+  　<div class="border border-primary">
+  　 
+  　　<label><%= f.radio_button :address_number,3,checked: "checked" %>新しい住所</label>
+
+      <div class="form-group">
+        <%= f.label :配送先宛名 %><br>
+        <%= f.text_field :name, class:"form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :配送先郵便番号 %><br>
+        <%= f.text_field :postal_code, class:"form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :配送先住所 %><br>
+        <%= f.text_area :address, class:"form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :送料 %><br>
+        <%= f.number_field :shipping_cost, class:"form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :請求額 %><br>
+        <%= f.number_field :total_payment, class:"form-control" %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :注文ステータス %><br>
+        <%= f.text_area :status, class:"form-control" %>
+      </div>
+
+  　</div>
     <%= f.submit "確認画面へ進む", class:"btn btn-success" %>
-  
+
   <% end %>
-  
+
 </div>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -1,2 +1,22 @@
-<h1>Public::Orders#show</h1>
-<p>Find me in app/views/public/orders/show.html.erb</p>
+<div class="container">
+  <h1>注文情報の詳細</h1>
+  
+  <h5>商品情報</h5>
+  <p>商品名</p>
+  <p>商品画像</p>
+  <p>商品値段（税込）</p>
+  <p>個数</p>
+  <p>商品合計</p>
+  
+
+  <h5><支払い方法></h5>
+  <span><%= @order.payment_method %></span>
+  
+  <h5><配送先情報></h5>
+  <span>宛先:<%= @order.name %></span><br>
+  <span>郵便番号:<%= @order.postal_code %></span><br>
+  <span>住所:<%= @order.address %></span>
+
+</div>
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,9 +19,9 @@ Rails.application.routes.draw do
     resource :customers, only: [:edit, :update]
     get 'customers/unsubscribe'
     patch 'customers/withdraw'
+    post 'orders/complete'
     resources :orders, only: [:new, :create, :index, :show]
     post 'orders/confirm'
-    get 'orders/complete'
     resources :addresses, only: [:index, :edit, :create, :update, :destroy]
   end
   


### PR DESCRIPTION
**消費者のモデル**
・modelのcustomer.rb
has_many :orders, dependent: :destroyを記述
Gitのdevelopみて変化なかったので、追加してもいいと思い追加しました。
→消費者の注文情報経歴を出す為。

**ルーテイング**
 'orders/complete’をgetからpost

**注文情報入力**
・支払いの選択
・お届け先選択
→登録済みの住所の選択は枠だけ

**注文情報確認画面**
・支払いの選択
・お届け先
・今は配送情報のみ保存できます
→カートの中身、商品小計、請求金額はまだです。

**注文完了画面**
・Viewの編集のみ

**注文経歴一覧**
・過去の注文履歴
・詳細リンクをクリック

**注文詳細**
・注文情報の詳細
→配送のみ
