### PR TITLE
消費者と配送先モデルのバリデーション設定

### DIFF
--- a/app/controllers/public/addresses_controller.rb
+++ b/app/controllers/public/addresses_controller.rb
@@ -5,13 +5,18 @@ class Public::AddressesController < ApplicationController
 
   def index
     @addresses = current_customer.addresses
+    @address = Address.new
   end
 
   def create
     @address = Address.new(address_params)
     @address.customer_id = current_customer.id
-    @address.save
-    redirect_to addresses_path
+    if @address.save
+      redirect_to addresses_path
+    else
+      @addresses = current_customer.addresses
+      render 'index'
+    end
   end
 
   def destroy
@@ -23,8 +28,11 @@ class Public::AddressesController < ApplicationController
   end
 
   def update
-    @address.update(address_params)
-    redirect_to addresses_path
+    if @address.update(address_params)
+      redirect_to addresses_path
+    else
+      render 'edit'
+    end
   end
 
   private

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,6 +1,6 @@
 class Public::CustomersController < ApplicationController
   before_action :set_customer, only: [:show, :edit, :update, :withdraw]
-  
+
   layout 'public'
 
   def show

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -10,8 +10,11 @@ class Public::CustomersController < ApplicationController
   end
 
   def update
-    @customer.update(customer_params)
-    render 'show'
+    if @customer.update(customer_params)
+      redirect_to customers_my_page_path
+    else
+      render 'edit'
+    end
   end
 
   def unsubscribe

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,3 +1,7 @@
 class Address < ApplicationRecord
   belongs_to :customer
+
+  validates :name, presence: true
+  validates :postal_code, presence: true, format: { with: /\A\d{7}\z/i}
+  validates :address, presence: true
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -3,8 +3,16 @@ class Customer < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   has_many :orders, dependent: :destroy
   has_many :addresses
-  
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  validates :last_name, presence: true
+  validates :first_name, presence: true
+  validates :last_name_kana, presence: true, format: {with: /\A[ァ-ヶー－]+\z/i}
+  validates :first_name_kana, presence: true, format: {with: /\A[ァ-ヶー－]+\z/i}
+  validates :postal_code, presence: true, format: { with: /\A\d{7}\z/i}
+  validates :address, presence: true
+  validates :telephone_number, presence: true, format: { with: /\A\d{10,11}\z/i}
 end
 

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -29,4 +29,3 @@
     <% end %>
   </tbody>
 </table>
-<%= link_to "sign_out", destroy_customer_session_path, method: :delete %>

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -29,3 +29,4 @@
     <% end %>
   </tbody>
 </table>
+<%= link_to "sign_out", destroy_customer_session_path, method: :delete %>

--- a/app/views/layouts/_errors.html.erb
+++ b/app/views/layouts/_errors.html.erb
@@ -1,0 +1,10 @@
+<% if obj.errors.any? %>
+  <div id="error_explanation">
+    <h3><%= pluralize(obj.errors.count, "error") %> prohibited this obj from being saved:</h3>
+    <ul>
+      <% obj.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/public/addresses/edit.html.erb
+++ b/app/views/public/addresses/edit.html.erb
@@ -3,18 +3,18 @@
 
 <%= form_with model: @address, local: true do |f| %>
   <div class="field">
-    <%= f.label :postal_code %><br />
-    <%= f.text_field :postal_code, autofocus: true %>
+    <%= f.label :postal_code, "郵便番号(ハイフン不要):" %><br />
+    <%= f.text_field :postal_code, autofocus: true, placeholder: "例)3810000" %>
   </div>
 
   <div class="field">
-    <%= f.label :address %><br />
-    <%= f.text_field :address, autofocus: true %>
+    <%= f.label :address, "住所(部屋番号まで)" %><br />
+    <%= f.text_field :address, autofocus: true, placeholder: "例)長野県長野市〇-〇-〇" %>
   </div>
 
   <div class="field">
-    <%= f.label :name %><br />
-    <%= f.text_field :name, autofocus: true %>
+    <%= f.label :name, "宛先:" %><br />
+    <%= f.text_field :name, autofocus: true, autofocus: true, placeholder: "例)長野花子" %>
   </div>
 
   <div class="actions">

--- a/app/views/public/addresses/edit.html.erb
+++ b/app/views/public/addresses/edit.html.erb
@@ -1,6 +1,7 @@
 <h1>Public::Addresses#edit</h1>
 <p>Find me in app/views/public/addresses/edit.html.erb</p>
 
+<%= render 'layouts/errors', obj: @address %>
 <%= form_with model: @address, local: true do |f| %>
   <div class="field">
     <%= f.label :postal_code, "郵便番号(ハイフン不要):" %><br />

--- a/app/views/public/addresses/index.html.erb
+++ b/app/views/public/addresses/index.html.erb
@@ -23,7 +23,8 @@
   </tbody>
 </table>
 
-<%= form_with model: Address.new, local: true do |f| %>
+<%= render 'layouts/errors', obj: @address %>
+<%= form_with model: @address, local: true do |f| %>
   <div class="field">
     <%= f.label :postal_code, "郵便番号(ハイフン不要):" %><br />
     <%= f.text_field :postal_code, autofocus: true, placeholder: "例)3810000" %>

--- a/app/views/public/addresses/index.html.erb
+++ b/app/views/public/addresses/index.html.erb
@@ -25,18 +25,18 @@
 
 <%= form_with model: Address.new, local: true do |f| %>
   <div class="field">
-    <%= f.label :postal_code %><br />
-    <%= f.text_field :postal_code, autofocus: true %>
+    <%= f.label :postal_code, "郵便番号(ハイフン不要):" %><br />
+    <%= f.text_field :postal_code, autofocus: true, placeholder: "例)3810000" %>
   </div>
 
   <div class="field">
-    <%= f.label :address %><br />
-    <%= f.text_field :address, autofocus: true %>
+    <%= f.label :address, "住所(部屋番号まで)" %><br />
+    <%= f.text_field :address, autofocus: true, placeholder: "例)長野県長野市〇-〇-〇" %>
   </div>
 
   <div class="field">
-    <%= f.label :name %><br />
-    <%= f.text_field :name, autofocus: true %>
+    <%= f.label :name, "宛先:" %><br />
+    <%= f.text_field :name, autofocus: true, placeholder: "例)長野花子" %>
   </div>
 
   <div class="actions">

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -1,6 +1,7 @@
 <h1>Public::Customers#edit</h1>
 <p>Find me in app/views/public/customers/edit.html.erb</p>
 
+<%= render 'layouts/errors', obj: @customer %>
 <%= form_with model: @customer, url: customers_path, local: true do |f| %>
   <div class="field">
     <%= f.label :last_name %><br />

--- a/app/views/public/registrations/new.html.erb
+++ b/app/views/public/registrations/new.html.erb
@@ -1,64 +1,61 @@
-<h2>Sign up</h2>
+<h2>会員新規登録</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "public/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :last_name %><br />
-    <%= f.text_field :last_name, autofocus: true %>
+    <%= f.label :last_name, "名前(姓):" %><br />
+    <%= f.text_field :last_name, autofocus: true, placeholder: "例)長野" %>
   </div>
 
   <div class="field">
-    <%= f.label :first_name %><br />
-    <%= f.text_field :first_name, autofocus: true %>
+    <%= f.label :first_name, "名前(名):" %><br />
+    <%= f.text_field :first_name, autofocus: true, placeholder: "例)花子" %>
   </div>
 
   <div class="field">
-    <%= f.label :last_name_kana %><br />
-    <%= f.text_field :last_name_kana, autofocus: true %>
+    <%= f.label :last_name_kana, "名前(セイ):" %><br />
+    <%= f.text_field :last_name_kana, autofocus: true, placeholder: "例)ナガノ" %>
   </div>
 
   <div class="field">
-    <%= f.label :first_name_kana %><br />
-    <%= f.text_field :first_name_kana, autofocus: true %>
+    <%= f.label :first_name_kana, "名前(メイ):" %><br />
+    <%= f.text_field :first_name_kana, autofocus: true, placeholder: "例)ハナコ" %>
   </div>
 
   <div class="field">
-    <%= f.label :postal_code %><br />
-    <%= f.text_field :postal_code, autofocus: true %>
-  </div>
-  
-  <div class="field">
-    <%= f.label :address %><br />
-    <%= f.text_field :address, autofocus: true %>
-  </div>
-  
-  <div class="field">
-    <%= f.label :telephone_number %><br />
-    <%= f.text_field :telephone_number, autofocus: true %>
+    <%= f.label :postal_code, "郵便番号(ハイフン不要):" %><br />
+    <%= f.text_field :postal_code, autofocus: true, placeholder: "例)3810000" %>
   </div>
 
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.label :address, "住所(部屋番号まで):" %><br />
+    <%= f.text_field :address, autofocus: true, placeholder: "例)長野県長野市〇-〇-〇" %>
   </div>
 
   <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
+    <%= f.label :telephone_number, "電話番号(ハイフン不要):" %><br />
+    <%= f.text_field :telephone_number, autofocus: true, placeholder: "例)09000000000" %>
   </div>
 
   <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%= f.label :email, "メールアドレス:" %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "例)nagano@cake.jp" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password, "パスワード(6文字以上):" %><br />
+    <%= f.password_field :password, autocomplete: "new-password", placeholder: "パスワードを入力して下さい" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "パスワード(確認):" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "パスワードを入力して下さい" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Sign up" %>
+    <%= f.submit "新規登録" %>
   </div>
 <% end %>
 
-<%= render "public/shared/links" %>
+<%= link_to "ログイン", new_session_path(resource_name) %>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -1,19 +1,19 @@
-<h2>Log in</h2>
+<h2>会員ログイン</h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.label :email, "メールアドレス:" %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレスを入力して下さい" %>
   </div>
 
   <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
+    <%= f.label :password, "パスワード(6文字以上):" %><br />
+    <%= f.password_field :password, autocomplete: "current-password", placeholder: "パスワードを入力して下さい" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit "ログイン" %>
   </div>
 <% end %>
 
-<%= render "public/shared/links" %>
+<%= link_to "新規登録", new_registration_path(resource_name) %>

--- a/app/views/public/shared/_links.html.erb
+++ b/app/views/public/shared/_links.html.erb
@@ -1,7 +1,0 @@
-<%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>


### PR DESCRIPTION
## 下記の通り、消費者と配送先モデルのバリデーション設定をした。 #46
### 全入力カラム対し
presence: true
### 名前(姓・名)
~~漢字・ひらがな・アルファベット~~ → 外国人の方も考慮し、制限しないことにした。
### 名前(姓カナ・名カナ)
**カタカナ**・~~アルファベット~~ → 読み方はカタカナが一般的であると考えたため。
### 郵便番号
統一したいので、ハイフン~~あり~~**なし** → 電話番号と揃えるため**なし**とした。
### 電話番号
統一したいので、ハイフン~~あり~~**なし** → 市外局番と携帯電話で異なる上、区切り方は人それぞれであるため。
## 何を入力してほしいか、ぱっと見分かるようにした。
placeholder: "例)〇〇"
## 何故弾かれたか分かるように、error messageを表示させるようにした。
error messageのテンプレートは、layoutフォルダに格納しておりますので、ご利用下さい。
※現状、error messageは英語表記のため、余力があれば日本語表記に書き換える。