### PR TITLE
sessionとregistration後のルーティング設定

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -2,7 +2,7 @@
 
 class Admin::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
-  
+
   layout 'admin'
 
   # GET /resource/sign_in
@@ -20,10 +20,18 @@ class Admin::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+  def after_sign_in_path_for(resource)
+    admin_root_path
+  end
+
+  def after_sign_out_path_for(resource)
+    new_admin_session_path
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,21 +1,2 @@
 class ApplicationController < ActionController::Base
-
-  before_action :configure_permitted_parameters, if: :devise_controller?
-
-
-  protected
-
-  def configure_permitted_parameters
-     list = [
-        :last_name,
-        :first_name,
-        :last_name_kana,
-        :first_name_kana,
-        :postal_code,
-        :address,
-        :telephone_number
-        ]
-    devise_parameter_sanitizer.permit(:sign_up, keys: list)
-  end
-
 end

--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -40,7 +40,7 @@ class Public::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
@@ -53,9 +53,9 @@ class Public::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_sign_up_path_for(resource)
+    customers_my_page_path
+  end
 
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)

--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Public::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
   layout 'public'
@@ -43,9 +43,18 @@ class Public::RegistrationsController < Devise::RegistrationsController
   protected
 
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+  def configure_sign_up_params
+    list = [
+        :last_name,
+        :first_name,
+        :last_name_kana,
+        :first_name_kana,
+        :postal_code,
+        :address,
+        :telephone_number
+        ]
+    devise_parameter_sanitizer.permit(:sign_up, keys: list)
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -2,7 +2,7 @@
 
 class Public::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
-  
+
   layout 'public'
 
   # GET /resource/sign_in
@@ -20,10 +20,18 @@ class Public::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+  def after_sign_in_path_for(resource)
+    root_path
+  end
+
+  def after_sign_out_path_for(resource)
+    root_path
+  end
 end


### PR DESCRIPTION
## sessionとregistration後のルーティングを以下の通り設定しました。 #54
### sessions controller
- 消費者
  - sign_in → homes#top
  - sign_out → homes#top
- 管理者
  - sign_in → homes#top
  - sign_out → sessions#new
### registrations controller
- 消費者
  - sign_up → customers#show
 ## sign_up時のストロングパラメーターの記述場所を変更しました。
application_controller → registrations_controller