### PR TITLE
バリデーション設定とヘッダーリンクの変更、ログアウト状態での画面制限

### DIFF
--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -1,5 +1,7 @@
 class Admin::GenresController < ApplicationController
 
+  before_action :authenticate_admin!
+
   layout 'admin'
 
   def index

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,5 +1,7 @@
 class Admin::ItemsController < ApplicationController
 
+  before_action :authenticate_admin!
+
   layout 'admin'
 
   def index

--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -1,5 +1,7 @@
 class Public::CartItemsController < ApplicationController
 
+  before_action :authenticate_customer!
+
   layout 'public'
 
 
@@ -15,7 +17,7 @@ class Public::CartItemsController < ApplicationController
       redirect_to cart_items_path
     else
       @item = Item.find_by(id: @cart_item.item_id)
-      redirect_to item_path(@item), flash: {alert: '※個数を選択して下さい'}
+      redirect_to item_path(@item), flash: {notice: '個数を選択して下さい'}
     end
   end
 

--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -1,7 +1,7 @@
 class Public::ItemsController < ApplicationController
-  
+
   layout 'public'
-  
+
   def index
     @items = Item.all
   end

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -37,7 +37,7 @@
                 </li>
 
                 <li class="nav-item">
-                  <%= link_to 'ログアウト', destroy_customer_session_path, method: :delete, class: "nav-link text-dark" %>
+                  <%= link_to 'ログアウト', destroy_admin_session_path, method: :delete, class: "nav-link text-dark" %>
                 </li>
 
               <% else %>
@@ -55,7 +55,7 @@
                 </li>
 
                 <li class="nav-item">
-                  <%= link_to 'ログイン', new_customer_session_path, class: "nav-link text-dark" %>
+                  <%= link_to 'ログイン', new_admin_session_path, class: "nav-link text-dark" %>
                 </li>
 
               <% end %>

--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -36,6 +36,10 @@
                   <%= link_to 'ログアウト', destroy_customer_session_path, method: :delete, class: "nav-link text-dark" %>
                 </li>
 
+                <li class="nav-item nav-link text-success">
+                  ログイン中：<%= current_customer.last_name %>
+                </li>
+
               <% else %>
 
                 <li class="nav-item">

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -1,5 +1,13 @@
 <div class="container">
 
+<div class="text-danger">
+  <% if flash[:notice] %>
+    <div class="flash">
+      <%= flash[:notice] %>
+    </div>
+  <% end %>
+</div>
+
   <div class="row mt-4 pt-4">
     <div class="col-md-5">
       <%= attachment_image_tag @item, :image, size: "250x250" %>


### PR DESCRIPTION
バリデーション設定でのエラーメッセージ表示と、admin側のログアウト時のヘッダーリンク修正
各authenticate_admin,customerの設定をしました。
※要件に、ログインしなくても商品一覧には入れるのでitemコントローラに入れてません。
※admin側の注文履歴ボタンは、まだ一覧がなかったため、設定してません。ビュー完成したらリンク先付け替えます。

確認後、マージお願いします。
