### PR TITLE
デバック完了

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -4,7 +4,7 @@ class Public::CartItemsController < ApplicationController
 
 
   def index
-    @cart_item = CartItem.where(customer_id: current_customer.id)
+    @cart_item = CartItem.where(customer_id: current_customer)
   end
 
   def create


### PR DESCRIPTION
Cloud9上のローカルブラウザにcart_itemコントローラのindexアクションに対して以下のエラーが発生していた（ロー買うブラウザを開いてもエラー画面は出ない）

nil 'id'

対処方法
👉indexアクションにあるインスタンス変数に対して渡した引数の「.id」を削除
　エラーは消えました（.idは不要だった）。

確認後、マージお願いします。