### PR TITLE
配送先新規登録のjpostalの修正

### DIFF
--- a/app/assets/javascripts/address_jpostal.js
+++ b/app/assets/javascripts/address_jpostal.js
@@ -13,7 +13,7 @@ $(function() {
   return $("#address_postal_code").jpostal({
     postcode: ["#address_postal_code"],
     address: {
-      "#address_postal_code": '%3%4%5',
+      "#address_address": '%3%4%5',
     },
   });
 });


### PR DESCRIPTION
通常の読み込み時の記述が誤っていたため修正した。#75