### PR TITLE
[update]販売停止の商品が買えるバグを修正 #112

### DIFF
--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -10,6 +10,9 @@
         <p class="item-img"><%= link_to item_path(item.id) do %><%= attachment_image_tag item, :image, size: "175x175", class: "rounded-circle" %><% end %></p>
         <p class="ml-3 font"><%= item.name %></p>
         <p class="ml-3 font">¥<%= ((item.price * 1.1).floor).to_s(:delimited) %></p>
+      <% if item.is_active == false %>
+        <p class="text-danger">売り切れ</p>
+      <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -15,11 +15,14 @@
       <p class="mb-4 font"><%= @item.introduction %></p>
       <p class="mb-4 font">¥<%= ((@item.price * 1.1).floor).to_s(:delimited) %><small>(税込)</small></p>
 
-
-      <%= form_with model: @cart_items, url: cart_items_path, local: true do |f| %>
-        <%= f.hidden_field :item_id, value: @item.id %>
-        <%= f.select :amount, options_for_select((1..20).to_a), include_blank: "個数選択" %>
-        <%= f.submit 'カートに入れる', class: "btn btn-success ml-4" %>
+      <% if @item.is_active == true %>
+        <%= form_with model: @cart_items, url: cart_items_path, local: true do |f| %>
+          <%= f.hidden_field :item_id, value: @item.id %>
+          <%= f.select :amount, options_for_select((1..20).to_a), include_blank: "個数選択" %>
+          <%= f.submit 'カートに入れる', class: "btn btn-success ml-4" %>
+        <% end %>
+      <% else %>
+        <p class="text-danger h4">売り切れ</p>
       <% end %>
 
     </div>


### PR DESCRIPTION
商品一覧と商品詳細画面に「売り切れ」の文字を表示し、商品詳細にある
個数選択のプルダウンを消すようにIf文で管理した。
販売中のステータスに切り替えると、ちゃんと購入できることを確認済み。
確認後、マージお願いいたします。