### PR TITLE
商品が空の状態での購入を禁止

### DIFF
--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -60,9 +60,11 @@
     </div>
   </div>
 
-  <div class="row">
-    <div class="col-md-2 mx-auto mt-4 mb-4">
-      <p><%= link_to '情報入力に進む', new_order_path, class: "btn btn-success btn-block font"%></p>
+  <% if @cart_item != [] %>
+    <div class="row">
+      <div class="col-md-2 mx-auto mt-4 mb-4">
+          <p><%= link_to '情報入力に進む', new_order_path, class: "btn btn-success btn-block font"%></p>
+      </div>
     </div>
-  </div>
+  <% end %>
 </div>


### PR DESCRIPTION
商品がない状態で購入が可能となっているため、
商品がない場合はpublic/cart_items#indexのページに"情報入力に進む"ボタンを表示させないようにした。