### PR TITLE
注文情報入力画面の修正

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -8,6 +8,7 @@ class Public::OrdersController < ApplicationController
     @order = Order.new
     @customer = current_customer
     @address = Address.new
+    @selected_pay =false
     @radio_check1 = "checked"
     @radio_check2 = ""
     @radio_check3 = ""
@@ -51,6 +52,7 @@ class Public::OrdersController < ApplicationController
       elsif params[:order][:address_number]=="2"
 
         if params[:order][:payment_method] != ""
+          @selected_pay = params[:order][:payment_method]
           if params[:order][:address_id] == ""
             flash[:alert] = "空欄はダメだよ"
             @radio_check2 = "checked"
@@ -83,7 +85,9 @@ class Public::OrdersController < ApplicationController
               @order.name = params[:order][:name]
               @order.postal_code = params[:order][:postal_code]
             else
+              @selected_pay = params[:order][:payment_method]
               flash[:alert] = "空欄はダメだよ"
+              @radio_check3 = "checked"
               render 'new'
             end
 

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -1,6 +1,6 @@
 class Public::OrdersController < ApplicationController
   before_action :authenticate_customer!
-
+  before_action :set_new_message, only:[:new, :confirm]
 
   layout 'public'
 
@@ -8,14 +8,7 @@ class Public::OrdersController < ApplicationController
     @order = Order.new
     @customer = current_customer
     @address = Address.new
-    @selected_pay = false
-    @selected_delivery = false
     @radio_check1 = "checked"
-    @radio_check2 = ""
-    @radio_check3 = ""
-    flash[:ale] = false
-    flash[:alert2] = false
-    flash[:alert3] = false
   end
 
   def index
@@ -33,80 +26,69 @@ class Public::OrdersController < ApplicationController
 
   def confirm
     @order = Order.new(order_params)
-    @selected_pay = false
-    @selected_delivery = false
-    @radio_check1 = ""
-    @radio_check2 = ""
-    @radio_check3 = ""
-    flash[:ale] = false
-    flash[:alert2] = false
-    flash[:alert3] = false
+    @selected_pay = params[:order][:payment_method]
+    select_radio = params[:order][:address_number]
+    @selected_delivery = params[:order][:address_id]
 
-      if params[:order][:address_number]=="1"
-
-        if params[:order][:payment_method] != ""
-          @order.postal_code = current_customer.postal_code
-          @order.address = current_customer.address
-          @order.name = current_customer.last_name + current_customer.first_name
+    case select_radio
+    when "1"
+      if @selected_pay.present?
+        @order.postal_code = current_customer.postal_code
+        @order.address = current_customer.address
+        @order.name = current_customer.last_name + current_customer.first_name
+      else
+        flash[:alert_pay] = "選択して下さい"
+        @radio_check1 = "checked"
+        render 'new'
+      end
+    when "2"
+      if @selected_pay.present?
+        if @selected_delivery.present?
+          select_address = Address.find(@selected_delivery)
+          @order.postal_code = select_address.postal_code
+          @order.address = select_address.address
+          @order.name = select_address.name
         else
-          flash[:ale] = "選択して下さい"
-          @radio_check1 = "checked"
-          render 'new'
-        end
-
-      elsif params[:order][:address_number]=="2"
-
-        if params[:order][:payment_method] != ""
-          @selected_pay = params[:order][:payment_method]
-          if params[:order][:address_id] == ""
-            flash[:alert2] = "選択して下さい"
-            @radio_check2 = "checked"
-            render 'new'
-          else
-            @order.postal_code = Address.find(params[:order][:address_id]).postal_code
-            @order.address = Address.find(params[:order][:address_id]).address
-            @order.name = Address.find(params[:order][:address_id]).name
-          end
-        else
-          if params[:order][:address_id] == ""
-            flash[:alert2] = "選択して下さい"
-          end
-          @selected_delivery = params[:order][:address_id]
-          flash[:ale] = "選択して下さい"
+          flash[:alert2] = "選択して下さい"
           @radio_check2 = "checked"
           render 'new'
         end
-
-      elsif params[:order][:address_number]=="3"
-
-        if params[:order][:payment_method] != ""
-
-            @address = Address.new()
-            @address.address = params[:order][:address]
-            @address.name = params[:order][:name]
-            @address.postal_code = params[:order][:postal_code]
-            @address.customer_id = current_customer.id
-            if @address.save
-              @order.address = params[:order][:address]
-              @order.name = params[:order][:name]
-              @order.postal_code = params[:order][:postal_code]
-            else
-              @selected_pay = params[:order][:payment_method]
-              flash[:alert3] = "空欄はダメだよ"
-              @radio_check3 = "checked"
-              render 'new'
-            end
-
+      else
+        flash[:alert_pay] = "選択して下さい"
+        @radio_check2 = "checked"
+        if @selected_delivery.empty?
+          flash[:alert2] = "選択して下さい"
+        end
+        render 'new'
+      end
+    when "3"
+      new_postal_code = params[:order][:postal_code]
+      new_address = params[:order][:address]
+      new_name = params[:order][:name]
+      if @selected_pay.present?
+        @address = Address.new()
+        @address.postal_code = new_postal_code
+        @address.address = new_address
+        @address.name = new_name
+        @address.customer_id = current_customer.id
+        if @address.save
+          @order.postal_code = new_postal_code
+          @order.address = new_address
+          @order.name = new_name
         else
-          flash[:ale] = "選択して下さい"
-          if params[:order][:address] == "" || params[:order][:name] == "" || params[:order][:postal_code] == ""
-            flash[:alert3] = "空欄はダメだよ"
-          end
+          flash[:alert3] = "空欄はダメだよ"
           @radio_check3 = "checked"
           render 'new'
         end
-
+      else
+        flash[:alert_pay] = "選択して下さい"
+        if new_postal_code.empty? || new_address.empty? || new_name.empty?
+          flash[:alert3] = "空欄はダメだよ"
+        end
+        @radio_check3 = "checked"
+        render 'new'
       end
+    end
 
     @cart_items = CartItem.where(customer_id: current_customer.id)
     @sum = 0
@@ -137,6 +119,18 @@ class Public::OrdersController < ApplicationController
   end
 
   private
+
+  def set_new_message
+    @selected_pay = false
+    @selected_delivery = false
+    @radio_check1 = ""
+    @radio_check2 = ""
+    @radio_check3 = ""
+    flash[:alert_pay] = false
+    flash[:alert2] = false
+    flash[:alert3] = false
+  end
+
   def order_params
     params.require(:order).permit(:customer_id, :postal_code, :address, :name, :total_payment, :payment_method, :shipping_cost)
 

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -8,12 +8,14 @@ class Public::OrdersController < ApplicationController
     @order = Order.new
     @customer = current_customer
     @address = Address.new
-    @selected_pay =false
+    @selected_pay = false
+    @selected_delivery = false
     @radio_check1 = "checked"
     @radio_check2 = ""
     @radio_check3 = ""
     flash[:ale] = false
-    flash[:alert] = false
+    flash[:alert2] = false
+    flash[:alert3] = false
   end
 
   def index
@@ -31,11 +33,14 @@ class Public::OrdersController < ApplicationController
 
   def confirm
     @order = Order.new(order_params)
+    @selected_pay = false
+    @selected_delivery = false
     @radio_check1 = ""
     @radio_check2 = ""
     @radio_check3 = ""
     flash[:ale] = false
-    flash[:alert] = false
+    flash[:alert2] = false
+    flash[:alert3] = false
 
       if params[:order][:address_number]=="1"
 
@@ -44,7 +49,7 @@ class Public::OrdersController < ApplicationController
           @order.address = current_customer.address
           @order.name = current_customer.last_name + current_customer.first_name
         else
-          flash[:ale] = "空欄はダメだよ"
+          flash[:ale] = "選択して下さい"
           @radio_check1 = "checked"
           render 'new'
         end
@@ -54,7 +59,7 @@ class Public::OrdersController < ApplicationController
         if params[:order][:payment_method] != ""
           @selected_pay = params[:order][:payment_method]
           if params[:order][:address_id] == ""
-            flash[:alert] = "空欄はダメだよ"
+            flash[:alert2] = "選択して下さい"
             @radio_check2 = "checked"
             render 'new'
           else
@@ -64,9 +69,10 @@ class Public::OrdersController < ApplicationController
           end
         else
           if params[:order][:address_id] == ""
-            flash[:alert] = "空欄はダメだよ"
+            flash[:alert2] = "選択して下さい"
           end
-          flash[:ale] = "空欄はダメだよ"
+          @selected_delivery = params[:order][:address_id]
+          flash[:ale] = "選択して下さい"
           @radio_check2 = "checked"
           render 'new'
         end
@@ -86,15 +92,15 @@ class Public::OrdersController < ApplicationController
               @order.postal_code = params[:order][:postal_code]
             else
               @selected_pay = params[:order][:payment_method]
-              flash[:alert] = "空欄はダメだよ"
+              flash[:alert3] = "空欄はダメだよ"
               @radio_check3 = "checked"
               render 'new'
             end
 
         else
-          flash[:ale] = "空欄はダメだよ"
+          flash[:ale] = "選択して下さい"
           if params[:order][:address] == "" || params[:order][:name] == "" || params[:order][:postal_code] == ""
-            flash[:alert] = "空欄はダメだよ"
+            flash[:alert3] = "空欄はダメだよ"
           end
           @radio_check3 = "checked"
           render 'new'

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -31,7 +31,8 @@ class Public::OrdersController < ApplicationController
     @radio_check1 = ""
     @radio_check2 = ""
     @radio_check3 = ""
-
+    flash[:ale] = false
+    flash[:alert] = false
 
       if params[:order][:address_number]=="1"
 
@@ -48,10 +49,19 @@ class Public::OrdersController < ApplicationController
       elsif params[:order][:address_number]=="2"
 
         if params[:order][:payment_method] != ""
-          @order.postal_code = Address.find(params[:order][:address_id]).postal_code
-          @order.address = Address.find(params[:order][:address_id]).address
-          @order.name = Address.find(params[:order][:address_id]).name
+          if params[:order][:address_id] == ""
+            flash[:alert] = "空欄はダメだよ"
+            @radio_check2 = "checked"
+            render 'new'
+          else
+            @order.postal_code = Address.find(params[:order][:address_id]).postal_code
+            @order.address = Address.find(params[:order][:address_id]).address
+            @order.name = Address.find(params[:order][:address_id]).name
+          end
         else
+          if params[:order][:address_id] == ""
+            flash[:alert] = "空欄はダメだよ"
+          end
           flash[:ale] = "空欄はダメだよ"
           @radio_check2 = "checked"
           render 'new'

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -8,6 +8,9 @@ class Public::OrdersController < ApplicationController
     @order = Order.new
     @customer = current_customer
     @address = Address.new
+    @radio_check1 = "checked"
+    @radio_check2 = ""
+    @radio_check3 = ""
   end
 
   def index
@@ -25,6 +28,9 @@ class Public::OrdersController < ApplicationController
 
   def confirm
     @order = Order.new(order_params)
+    @radio_check1 = ""
+    @radio_check2 = ""
+    @radio_check3 = ""
 
 
       if params[:order][:address_number]=="1"
@@ -35,7 +41,8 @@ class Public::OrdersController < ApplicationController
           @order.name = current_customer.last_name + current_customer.first_name
         else
           flash[:ale] = "空欄はダメだよ"
-          redirect_to new_order_path
+          @radio_check1 = "checked"
+          render 'new'
         end
 
       elsif params[:order][:address_number]=="2"
@@ -46,7 +53,8 @@ class Public::OrdersController < ApplicationController
           @order.name = Address.find(params[:order][:address_id]).name
         else
           flash[:ale] = "空欄はダメだよ"
-          redirect_to new_order_path
+          @radio_check2 = "checked"
+          render 'new'
         end
 
       elsif params[:order][:address_number]=="3"
@@ -67,12 +75,13 @@ class Public::OrdersController < ApplicationController
             @order.customer_id = current_customer.id
           else
             flash[:alert] = "空欄はダメだよ"
-            redirect_to new_order_path
+            render 'new'
           end
 
         else
           flash[:ale] = "空欄はダメだよ"
-          redirect_to new_order_path
+          @radio_check3 = "checked"
+          render 'new'
         end
 
       end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -11,6 +11,8 @@ class Public::OrdersController < ApplicationController
     @radio_check1 = "checked"
     @radio_check2 = ""
     @radio_check3 = ""
+    flash[:ale] = false
+    flash[:alert] = false
   end
 
   def index
@@ -76,20 +78,20 @@ class Public::OrdersController < ApplicationController
             @address.name = params[:order][:name]
             @address.postal_code = params[:order][:postal_code]
             @address.customer_id = current_customer.id
-            @address.save!
-
-          if params[:order][:address] != "" && params[:order][:name] != "" && params[:order][:postal_code] != ""
-            @order.address = params[:order][:address]
-            @order.name = params[:order][:name]
-            @order.postal_code = params[:order][:postal_code]
-            @order.customer_id = current_customer.id
-          else
-            flash[:alert] = "空欄はダメだよ"
-            render 'new'
-          end
+            if @address.save
+              @order.address = params[:order][:address]
+              @order.name = params[:order][:name]
+              @order.postal_code = params[:order][:postal_code]
+            else
+              flash[:alert] = "空欄はダメだよ"
+              render 'new'
+            end
 
         else
           flash[:ale] = "空欄はダメだよ"
+          if params[:order][:address] == "" || params[:order][:name] == "" || params[:order][:postal_code] == ""
+            flash[:alert] = "空欄はダメだよ"
+          end
           @radio_check3 = "checked"
           render 'new'
         end

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -28,23 +28,28 @@
           </tr>
         </thead>
       </table>
-      <% if flash[:alert] %>
-        <div class="flash h5 mt-3 text-danger">
-          <%= flash[:alert] %>
-        </div>
-      <% end %>
       <div id="p1">
         <%= current_customer.last_name %><%= current_customer.first_name %>
       　〒<%= current_customer.postal_code.slice(0, 3) %>-<%= current_customer.postal_code.slice(3, 4) %>
       　<%= current_customer.address %>
       </div>
       <div id="p2">
-        <span>＊登録されている中からお選びください＊</span><br>
+        <% if flash[:alert2] %>
+        <div class="flash h5 mt-3 text-danger">
+          <%= flash[:alert2] %>
+        </div>
+        <% end %>
         <%= f.collection_select :address_id, current_customer.addresses, :id, :address_all,
+                                selected: @selected_delivery,
                                 include_blank: "＊お選びください＊",
                                 class: 'selectpicker form-control' %>
       </div>
       <div id="p3">
+        <% if flash[:alert3] %>
+          <div class="flash h5 mt-3 text-danger">
+            <%= flash[:alert3] %>
+          </div>
+        <% end %>
         <span>＊ご記入下さい＊</span><br>
         <div class="form-group">
           <%= f.label :name, "配送先宛名" %>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -22,9 +22,9 @@
       <table class="table">
         <thead>
           <tr>
-            <th><%= f.radio_button :address_number,1,checked: "checked", id: 'button1' %> あなたの住所</th>
-            <th><%= f.radio_button :address_number,2, id: 'button2' %> 登録されている住所</th>
-            <th><%= f.radio_button :address_number,3, id: 'button3' %>新しい住所</th>
+            <th><%= f.radio_button :address_number, 1, checked: @radio_check1, id: 'button1' %> あなたの住所</th>
+            <th><%= f.radio_button :address_number, 2, checked: @radio_check2, id: 'button2' %> 登録されている住所</th>
+            <th><%= f.radio_button :address_number, 3, checked: @radio_check3, id: 'button3' %>新しい住所</th>
           </tr>
         </thead>
       </table>
@@ -69,10 +69,17 @@
 <script>
 
 	// 初期表示を非表示にする
-	$('#p1').show();
+	$('#p1').hide();
 	$('#p2').hide();
 	$('#p3').hide();
 
+	<% if @radio_check1 == "checked" %>
+	  $('#p1').show();
+	<% elsif @radio_check2 == "checked" %>
+	  $('#p2').show();
+	<% else %>
+	  $('#p3').show();
+	<% end %>
 
 	$("#button1").click(function() {
 		// 表示する

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -101,5 +101,12 @@
 		$("#p2").hide();
 		$("#p3").show();
 	});
+
+// 	reload対策
+	$(function(){
+	  let path = location.pathname;
+    let pattern = "orders/confirm"
+    if(path.match(pattern)) history.replaceState(null,null,"/orders/new");
+	});
 </script>
 

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -28,6 +28,11 @@
           </tr>
         </thead>
       </table>
+      <% if flash[:alert] %>
+        <div class="flash h5 mt-3 text-danger">
+          <%= flash[:alert] %>
+        </div>
+      <% end %>
       <div id="p1">
         <%= current_customer.last_name %><%= current_customer.first_name %>
       　〒<%= current_customer.postal_code.slice(0, 3) %>-<%= current_customer.postal_code.slice(3, 4) %>
@@ -40,11 +45,6 @@
                                 class: 'selectpicker form-control' %>
       </div>
       <div id="p3">
-        <% if flash[:alert] %>
-          <div class="flash h5 mt-3 text-danger">
-            <%= flash[:alert] %>
-          </div>
-        <% end %>
         <span>＊ご記入下さい＊</span><br>
         <div class="form-group">
           <%= f.label :name, "配送先宛名" %>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -12,7 +12,7 @@
         </div>
       <% end %>
       <div class="form-group">
-        <%= f.select :payment_method, options_for_select(Order.payment_methods.keys),
+        <%= f.select :payment_method, options_for_select(Order.payment_methods.keys, @selected_pay),
                       include_blank: "＊お選びください＊",
                       class: 'selectpicker form-control' %>
       </div>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -6,9 +6,9 @@
   <%= form_with(model: @order, local: true, url: orders_confirm_path, method: :post) do |f| %>
     <div class="col-md-8">
       <p class="h5">支払方法</p>
-      <% if flash[:ale] %>
+      <% if flash[:alert_pay] %>
         <div class="flash h5 mt-3 text-danger">
-          <%= flash[:ale] %>
+          <%= flash[:alert_pay] %>
         </div>
       <% end %>
       <div class="form-group">


### PR DESCRIPTION
- 支払方法未選択エラー時の配送先住所選択画面(ラジオボタンで選択した際に表示される画面)を保持
- 「登録されている住所」と「新しい住所」のバリデーションを追加
- 「登録されている住所」選択時に発生したエラー表示時(支払方法未選択に対する)に、選択していた住所内容を保持
- 「新しい住所」選択時に発生したエラー表示時に、入力済みデータを保持
- 配送先未入力or未選択に対するエラー時の支払方法の選択を保持